### PR TITLE
bpo-40126: Fix attribute out of scope during error handling in mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1244,6 +1244,7 @@ class _patch(object):
         def patched(*args, **keywargs):
             extra_args = []
             entered_patchers = []
+            patching = None
 
             exc_info = tuple()
             try:


### PR DESCRIPTION
Resolves an issue where the `patching` attribute raises `UnboundLocalError` as it can be out of scope if there is an error before assignment in loop execution (e.g. if `patched.patchings is None`). This can happen if a library clears `patchings` in its own decorator cleanup.

https://bugs.python.org/issue40126